### PR TITLE
Change namespace within shared.hpp

### DIFF
--- a/shared.hpp
+++ b/shared.hpp
@@ -3,8 +3,6 @@
 #include <string> //for str operations
 #include <unistd.h>
 
-using namespace std;
-
 // a general matrix style structure
 template <typename T>
 struct matrix{


### PR DESCRIPTION
Hello,

I got rid of the `using namespace std;` from `shared.hpp` so that array types can be found. This fixes errors when compiling on Mac OS X 10.11.4, and retains compatibility with other systems (tested on CentOS 6.7, Ubuntu 15.10, and Mac OS X 10.11.3)

This addresses Issue #3 