### PR TITLE
CC -> CXX; ensure CXX can be set from the env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 
 TOOLS = ngs2dSFS ngsCovar ngsFST ngsStat
 
-CC = g++
+CCX ?= g++
 CFLAGS = -lm -lz -O3 -Wall
 
 all: $(TOOLS)
 
 $(TOOLS):
-	$(CC) $(CFLAGS) $@.cpp -o $@
+	$(CXX) $(CFLAGS) $@.cpp -o $@
 
 test:
 	@cd examples/; bash test.sh 2> test.log; cd ../


### PR DESCRIPTION
Change the CC variable in the Makefile to CXX to be a bit more standard.  Allow CXX to be set from the environment.